### PR TITLE
Update to blender 5.0

### DIFF
--- a/.github/workflows/archive_build.yml
+++ b/.github/workflows/archive_build.yml
@@ -1,0 +1,33 @@
+name: Zip and Archive Artifact
+
+on:
+  push:
+    tags:
+      - 'v*.*.*' # Trigger when a tag starting with 'v' is pushed
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository code
+        uses: actions/checkout@v4 # Action to get your code onto the runner machine.
+
+      - name: Zip artifact for deployment
+        # The 'zip' command is generally available on Ubuntu runners.
+        # The -r flag is for recursive zipping of directories.
+        run: cd src && zip -r ../io_scene_rsw.zip . && cd ..
+
+      - name: Upload zip artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: project-files
+          path: io_scene_rsw.zip # The path to the created zip file.
+          retention-days: 5 # Optional: How long to keep the artifact (default is 90 days)
+      - name: Create Release and Upload Asset
+        uses: softprops/action-gh-release@v1
+        with:
+          files: io_scene_rsw.zip # Glob patterns are supported
+          name: "Release ${{ github.ref_name }}"
+          body: "Automatic release notes for ${{ github.ref_name }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/io/reader.py
+++ b/src/io/reader.py
@@ -13,16 +13,15 @@ class BinaryFileReader(object):
     def read(self, fmt):
         return struct.unpack(fmt, self.file.read(struct.calcsize(fmt)))
 
-    def read_fixed_length_null_terminated_string(self, n, encoding='euc-kr'):
+    def read_fixed_length_null_terminated_string(self, length, encoding='cp949'):
         buf = bytearray()
-        for i in range(n):
+        for i in range(length):
             c = self.file.read(1)[0]
             if c == 0:
-                self.file.seek(n - i - 1, os.SEEK_CUR)
+                self.file.seek(length - i - 1, os.SEEK_CUR)
                 break
             buf.append(c)
         try:
-            return buf.decode(encoding)
+            return buf.decode('cp949')
         except UnicodeDecodeError as e:
-            print(buf)
-            raise e
+            return buf.decode('latin-1')

--- a/src/rsw/reader.py
+++ b/src/rsw/reader.py
@@ -13,7 +13,7 @@ class RswReader(object):
         pass
 
     @staticmethod
-    def from_file(path):
+    def from_file(path) -> Rsw:
         rsw = Rsw()
         with open(path, 'rb') as f:
             reader = BinaryFileReader(f)
@@ -97,4 +97,6 @@ class RswReader(object):
             if version >= Version(2, 1):
                 # Not necessary for our purposes, so just ignore it.
                 pass
+            rsw.rsw_version.major = version.major
+            rsw.rsw_version.minor = version.minor
         return rsw

--- a/src/rsw/rsw.py
+++ b/src/rsw/rsw.py
@@ -41,6 +41,11 @@ class Rsw(object):
             self.rotation = (0.0, 0.0, 0.0)
             self.scale = (1.0, 1.0, 1.0)
 
+    class Version(object):
+        def __init__(self):
+            self.major = 0
+            self.minor = 0
+
     def __init__(self):
         self.ini_file = ''
         self.gnd_file = ''
@@ -51,5 +56,6 @@ class Rsw(object):
         self.models = []
         self.light_sources = []
         self.sounds = []
+        self.rsw_version = Rsw.Version()
         self.effects = []
         pass


### PR DESCRIPTION
Add
- Adding the tag `v*.*.*` to Git will create a release file. For example, attach the Git Tag `v2026.1.1.`
- fix rsm scale
- fix Blender 5.0
- fix korea filename
- some rsw rotation
- some rsw position
- log rsw version
- fix origin rsm to center lowest point
- fix orgin gnd to the bottom and corners of the rectangle to correct any distorted map positioning.

The file structure issues with newer RSW versions haven't been fixed yet. Some RSW files still have problems, and the rotation position looks normal on the izlu2dun.rsw map, but distorts on other maps. I haven't investigated the cause yet. Also, some RSM files containing more than one model seem to have positional discrepancies. In the original izlu2dun.rsw file, the ship size and object positions appear incorrect, but everything else matches what's viewed in the Grf Editor.